### PR TITLE
draft: fix style

### DIFF
--- a/Formula/openssl@1.0.2t.rb
+++ b/Formula/openssl@1.0.2t.rb
@@ -10,10 +10,10 @@ class OpensslAT102t < Formula
   sha256 "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc"
 
   bottle do
-    sha256 "c9c5e017edabe41ae55ed10ba5b94b834ee494e7f362d7245fbb0b137c876810" => :catalina
-    sha256 "9874b2baf00f845355b163cb63b5c98a94a5cf7c08cda1d19876899b11b585c6" => :mojave
-    sha256 "20fa4d39cbc0ba091aed2ce72a4404e87c3bc323243ab3f92ccfd75c48cbe132" => :high_sierra
-    sha256 "bdbc44c56f63f27ab4dc12583b7f46a6485500f2a583dc8c9b848c4063f58927" => :sierra
+    sha256 catalina:    "c9c5e017edabe41ae55ed10ba5b94b834ee494e7f362d7245fbb0b137c876810"
+    sha256 mojave:      "9874b2baf00f845355b163cb63b5c98a94a5cf7c08cda1d19876899b11b585c6"
+    sha256 high_sierra: "20fa4d39cbc0ba091aed2ce72a4404e87c3bc323243ab3f92ccfd75c48cbe132"
+    sha256 sierra:      "bdbc44c56f63f27ab4dc12583b7f46a6485500f2a583dc8c9b848c4063f58927"
   end
 
   keg_only :provided_by_macos,
@@ -72,15 +72,16 @@ class OpensslAT102t < Formula
     (openssldir/"cert.pem").atomic_write(valid_certs.join("\n") << "\n")
   end
 
-  def caveats; <<~EOS
-    A CA file has been bootstrapped using certificates from the SystemRoots
-    keychain. To add additional certificates (e.g. the certificates added in
-    the System keychain), place .pem files in
-      #{openssldir}/certs
+  def caveats
+    <<~EOS
+      A CA file has been bootstrapped using certificates from the SystemRoots
+      keychain. To add additional certificates (e.g. the certificates added in
+      the System keychain), place .pem files in
+        #{openssldir}/certs
 
-    and run
-      #{opt_bin}/c_rehash
-  EOS
+      and run
+        #{opt_bin}/c_rehash
+    EOS
   end
 
   test do


### PR DESCRIPTION
ran `brew styles --fix` on the formula

Error log before fixing style
```bash
Installing Homebrew...
Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
Bash. Please migrate to the following command:
  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

==> Checking for `sudo` access (which may request your password).
Need sudo access on macOS (e.g. the user mbae needs to be an Administrator)!
Installing native dependencies...
Using homebrew/cask
Using homebrew/cask
==> Tapping navigatingcancer/openssl-1.0.2t
Cloning into '/usr/local/Homebrew/Library/Taps/navigatingcancer/homebrew-openssl-1.0.2t'...
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/navigatingcancer/homebrew-openssl-1.0.2t/Formula/openssl@1.0.2t.rb
openssl@1.0.2t: Calling `sha256 "digest" => :tag` in a bottle block is disabled! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Error: Cannot tap navigatingcancer/openssl-1.0.2t: invalid syntax in tap!
Tapping navigatingcancer/homebrew-openssl-1.0.2t has failed!
```

Note:
I had to install openSSL using
`brew install --build-from-source openssl@1.0.2t`

due to this error:
```bash
Tapping navigatingcancer/homebrew-openssl-1.0.2t
Using mysql@5.6
Using direnv
Using openssl
==> Downloading https://ghcr.io/v2/homebrew/core/openssl/1.0.2t/manifests/1.0.2t
curl: (22) The requested URL returned error: 404
Error: Failed to download resource "openssl@1.0.2t_bottle_manifest"
Download failed: https://ghcr.io/v2/homebrew/core/openssl/1.0.2t/manifests/1.0.2t
Installing openssl@1.0.2t has failed! :try
```

